### PR TITLE
Fixes after defense reunion

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule, ConfigService} from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { ChallengeModule } from './challenge/challenge.module';
@@ -10,6 +10,7 @@ import { Challenge, ChallengeSchema } from './models/challenge.schema';
 import { HealthMetric, HealthMetricSchema } from './models/healthMetric.schema';
 import { User, UserSchema } from './models/user.schema';
 import { UserChallenge, UserChallengeSchema } from './models/userChallenge.schema';
+import { NormalizeDatesMiddleware } from './middlewares/normalize-dates.middleware';
 @Module({
   imports: [
     ConfigModule.forRoot({isGlobal: true}),
@@ -43,4 +44,8 @@ import { UserChallenge, UserChallengeSchema } from './models/userChallenge.schem
   ],
   providers: [HealthMetricWorker],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(NormalizeDatesMiddleware).forRoutes('*');
+  }
+}

--- a/src/interceptors/health-metric-throttle.interceptor.ts
+++ b/src/interceptors/health-metric-throttle.interceptor.ts
@@ -26,7 +26,11 @@ export class HealthMetricThrottleInterceptor implements NestInterceptor {
       jobId: jobKey,
       removeOnComplete: true,
       removeOnFail: true,
-      attempts: 1,
+      attempts: 3,
+      backoff: {
+        type: 'exponential',
+        delay: 3000
+      },
     };
 
     return from(

--- a/src/middlewares/normalize-dates.middleware.ts
+++ b/src/middlewares/normalize-dates.middleware.ts
@@ -1,0 +1,27 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+
+@Injectable()
+export class NormalizeDatesMiddleware implements NestMiddleware {
+  use(req: any, res: any, next: () => void) {
+    if (req.body) {
+      this.normalize(req.body);
+    }
+    next();
+  }
+
+  private normalize(obj: any) {
+    for (const key in obj) {
+      if (!obj.hasOwnProperty(key)) continue;
+
+      const val = obj[key];
+
+      if (typeof val === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(val)) {
+        obj[key] = new Date(val);
+      }
+      // Si es objeto anidado → recurse
+      if (typeof val === 'object' && val !== null) {
+        this.normalize(val);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Pequeña PR con correciones cortas/basicas de lo hablado durante la reunion, queria aprovechar de corregir las cosas que me parecian que eran rapidas de arreglar y dejar el PR con los cambios, estos cambios implementarian:

.-Middleware para normalizar todas las fechas a UTC centralizado para evitar desfaces entre zonas horarias.
.- Sistema de retries en la queue (Que ya estaba pero con un solo retry).
.- Modificacion para buscar de actualizar el progreso especifico del reto activo del usuario, ademas usamos el ultimo valor registrado en HealthMetric y no dependemos del body enviado para mejorar la consistencia de datos.
.- Ya no se va rodando la fecha de completedAt en los desafios.